### PR TITLE
refactor: accept Path for done checks

### DIFF
--- a/FECalc/FECalc.py
+++ b/FECalc/FECalc.py
@@ -84,39 +84,38 @@ class FECalc():
         self.metad_pace = int(kwargs.get("metad_pace", 500))
         self.metad_bias_factor = float(kwargs.get("metad_bias_factor", 20))
     
-    def _check_done(self, stage: str) -> bool:
+    def _check_done(self, stage: Path) -> bool:
         """
-        Check if calculation has been performed already
+        Check if a calculation stage has already been performed.
+
         Args:
-            stage (str): calculation stage to check
+            stage (Path): Directory for the calculation stage.
 
         Returns:
-            bool: True if done, False otherwise
+            bool: True if the stage has a ".done" file, False otherwise.
         """
-        try:
-            with cd(self.base_dir/stage):
-                done_dir = self.base_dir/stage/".done"
-                if done_dir.exists():
-                    return True
-                else:
-                    return False
-        except:
-            return False
-    
-    def _set_done(self, stage: str) -> None:
+        stage_path = Path(stage)
+        if not stage_path.is_absolute():
+            stage_path = self.base_dir / stage_path
+        done_file = stage_path / ".done"
+        return done_file.exists()
+
+    def _set_done(self, stage: Path) -> None:
         """
-        create an empty file ".done" in the stage directory to mark is has been performed already.
+        Create an empty ".done" file in the stage directory to mark it as completed.
 
         Args:
-            stage (str): stage to set as done
+            stage (Path): Directory for the completed stage.
 
         Returns:
             None
         """
-        with cd(self.base_dir/stage):
-            done_dir = self.base_dir/stage/".done"
-            with open(done_dir, 'w') as f:
-                f.writelines([""])
+        stage_path = Path(stage)
+        if not stage_path.is_absolute():
+            stage_path = self.base_dir / stage_path
+        stage_path.mkdir(parents=True, exist_ok=True)
+        done_file = stage_path / ".done"
+        done_file.touch()
         return None
     
     def _get_atom_ids(self, gro_file: Path) -> None:

--- a/FECalc/PCCBuilder.py
+++ b/FECalc/PCCBuilder.py
@@ -64,39 +64,38 @@ class PCCBuilder():
 
         self.pymol = Path(self.settings['pymol_dir']) # path to pymol installation
 
-    def _check_done(self, stage: str) -> bool:
+    def _check_done(self, stage: Path) -> bool:
         """
-        Check if calculation has been performed already
+        Check if a calculation stage has been performed already.
+
         Args:
-            stage (str): calculation stage to check
+            stage (Path): Directory for the calculation stage.
 
         Returns:
-            bool: True if done, False otherwise
+            bool: True if a ".done" file exists, False otherwise.
         """
-        try:
-            with cd(self.base_dir/stage):
-                done_dir = self.base_dir/stage/".done"
-                if done_dir.exists():
-                    return True
-                else:
-                    return False
-        except:
-            return False
-    
-    def _set_done(self, stage: str) -> None:
+        stage_path = Path(stage)
+        if not stage_path.is_absolute():
+            stage_path = self.base_dir / stage_path
+        done_file = stage_path / ".done"
+        return done_file.exists()
+
+    def _set_done(self, stage: Path) -> None:
         """
-        create an empty file ".done" in the stage directory to mark is has been performed already.
+        Create an empty ".done" file in the stage directory to mark it as completed.
 
         Args:
-            stage (str): stage to set as done
+            stage (Path): Directory for the completed stage.
 
         Returns:
             None
         """
-        with cd(self.base_dir/stage):
-            done_dir = self.base_dir/stage/".done"
-            with open(done_dir, 'w') as f:
-                f.writelines([""])
+        stage_path = Path(stage)
+        if not stage_path.is_absolute():
+            stage_path = self.base_dir / stage_path
+        stage_path.mkdir(parents=True, exist_ok=True)
+        done_file = stage_path / ".done"
+        done_file.touch()
         return None
 
     def _create_pcc(self) -> None:

--- a/FECalc/TargetMOL.py
+++ b/FECalc/TargetMOL.py
@@ -46,39 +46,38 @@ class TargetMOL():
         self.input_pdb_dir = Path(self.settings["input_pdb_dir"]) if \
             self.settings.get("input_pdb_dir", None) is not None else None
 
-    def _check_done(self, stage: str) -> bool:
+    def _check_done(self, stage: Path) -> bool:
         """
-        Check if calculation has been performed already
+        Check if a calculation stage has already been performed.
+
         Args:
-            stage (str): calculation stage to check
+            stage (Path): Directory for the calculation stage.
 
         Returns:
-            bool: True if done, False otherwise
+            bool: True if a ".done" file exists, False otherwise.
         """
-        try:
-            with cd(self.base_dir/stage):
-                done_dir = self.base_dir/stage/".done"
-                if done_dir.exists():
-                    return True
-                else:
-                    return False
-        except:
-            return False
-    
-    def _set_done(self, stage: str) -> None:
+        stage_path = Path(stage)
+        if not stage_path.is_absolute():
+            stage_path = self.base_dir / stage_path
+        done_file = stage_path / ".done"
+        return done_file.exists()
+
+    def _set_done(self, stage: Path) -> None:
         """
-        create an empty file ".done" in the stage directory to mark is has been performed already.
+        Create an empty ".done" file in the stage directory to mark it as completed.
 
         Args:
-            stage (str): stage to set as done
+            stage (Path): Directory for the completed stage.
 
         Returns:
             None
         """
-        with cd(self.base_dir/stage):
-            done_dir = self.base_dir/stage/".done"
-            with open(done_dir, 'w') as f:
-                f.writelines([""])
+        stage_path = Path(stage)
+        if not stage_path.is_absolute():
+            stage_path = self.base_dir / stage_path
+        stage_path.mkdir(parents=True, exist_ok=True)
+        done_file = stage_path / ".done"
+        done_file.touch()
         return None
     
     def _get_n_atoms(self, gro_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- refactor done-file helpers to accept `Path` objects in FECalc, PCCBuilder and TargetMOL
- ensure relative paths resolve against `base_dir` and `.done` files are touched directly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'FECalc')*

------
https://chatgpt.com/codex/tasks/task_e_68b7340d303083309739c78f6f92cb07