### PR TITLE
Use named argument for box size in FECalc example

### DIFF
--- a/example/pcc_submit_test.py
+++ b/example/pcc_submit_test.py
@@ -26,7 +26,7 @@ PCC.create()
 MOL = TargetMOL(MOL_settings)
 MOL.create()
 complex_output = Path(settings["complex_output_dir"])/f"{PCC.PCC_code}_{MOL.name}"
-calculator = FECalc(PCC, MOL, complex_output, temperature, box_size, **metad_settings)
+calculator = FECalc(PCC, MOL, complex_output, temperature, box=box_size, **metad_settings)
 now = datetime.now()
 now = now.strftime("%m/%d/%Y, %H:%M:%S")
 print(f"Starting {PCC.PCC_code}_{MOL.name} run.")


### PR DESCRIPTION
## Summary
- Pass box size as a named argument when constructing `FECalc` in the submission example to avoid positional misalignment

## Testing
- `PYTHONPATH=. pytest` *(fails: FileNotFoundError: 'system_settings.JSON')*
- `PYTHONPATH=.. python example/pcc_submit_test.py` *(fails: subprocess.CalledProcessError: module load pymol not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7353585f483309930c01f0a8fcf82