### PR TITLE
Use Python IO to read GROMACS box size

### DIFF
--- a/FECalc/postprocess.py
+++ b/FECalc/postprocess.py
@@ -1,7 +1,6 @@
 import re
 import json
 from pathlib import Path
-import subprocess
 import numpy as np
 import pandas as pd
 from scipy.integrate import simpson
@@ -28,8 +27,22 @@ def _load_plumed(fname, KbT):
     return data
 
 def _get_box_size(gro_fname):
-    out = subprocess.run(f"tail -n 1 {gro_fname}", shell=True, capture_output=True)
-    return float(out.stdout.split()[0])
+    """Extract the box edge length from a GROMACS ``.gro`` file.
+
+    Parameters
+    ----------
+    gro_fname : Path or str
+        Path to the ``.gro`` structure file.
+
+    Returns
+    -------
+    float
+        The box edge length in nanometers.
+    """
+    with open(gro_fname, "r") as f:
+        for line in f:
+            pass
+    return float(line.split()[0])
 
 
 def _block_anal_3d(x, y, z, weights, KbT, nbins, folds):


### PR DESCRIPTION
## Summary
- replace subprocess tail invocation with direct Python file reading
- return box edge from `.gro` file last line without shell dependencies

## Testing
- `python -m py_compile FECalc/postprocess.py`
- `python -m pytest` *(fails: system_settings.JSON missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7428b20a08330b177117ea9f4b4c4