### PR TITLE
Remove unused script_dir variables

### DIFF
--- a/FECalc/FECalc.py
+++ b/FECalc/FECalc.py
@@ -38,7 +38,6 @@ class FECalc():
             pcc (PCCBuilder): PCC structure for FE calculations.
             target (TargetMol): Target molecule for FE calculations.
             base_dir (Path): directory to store the calculations
-            script_dir (Path): directory containing necessary scripts and templates
             temp (float): Temperature of the simulations
             box (float): Size of the simulation box
 
@@ -50,7 +49,6 @@ class FECalc():
         now = datetime.now()
         now = now.strftime("%m/%d/%Y, %H:%M:%S")
         print(f"{now}: Free energy calculations for {self.pcc.PCC_code} with {self.target.name} (PID: {os.getpid()})")
-        self.script_dir = Path(__file__).parent/Path("scripts")#Path(self.settings['scripts_dir'])
         self.mold_dir = Path(__file__).parent/Path("mold")
         self.base_dir = Path(base_dir) # base directory to store files
         if self.base_dir.exists():

--- a/FECalc/TargetMOL.py
+++ b/FECalc/TargetMOL.py
@@ -27,7 +27,6 @@ class TargetMOL():
         now = now.strftime("%m/%d/%Y, %H:%M:%S")
         print(f"{now}: Building and minimizing structure for {self.name} (PID: {os.getpid()})")
         
-        self.script_dir = Path(__file__).parent / Path("scripts")
         self.mold_dir = Path(__file__).parent / Path("mold")
 
         output_dir = self.settings.get("output_dir")


### PR DESCRIPTION
## Summary
- drop script_dir attributes from TargetMOL and FECalc modules
- clean up FECalc docstring referencing script_dir

## Testing
- `python -m py_compile FECalc/TargetMOL.py FECalc/FECalc.py`
- `PYTHONPATH=$PWD pytest` *(fails: FileNotFoundError: system_settings.JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68b752755fbc8330995b551fc6c82fc4