### PR TITLE
Simplify export stage in TargetMOL.create

### DIFF
--- a/FECalc/TargetMOL.py
+++ b/FECalc/TargetMOL.py
@@ -183,8 +183,7 @@ class TargetMOL():
             now = datetime.now()
             now = now.strftime("%m/%d/%Y, %H:%M:%S")
             print(f"{now}: Exporting files: ", end="", flush=True)
-            if not self._check_done(self.base_dir/'export'):
-                self._export()
+            self._export()
             print("\tDone.", flush=True)
             # Done
             now = datetime.now()


### PR DESCRIPTION
## Summary
- remove redundant export completion check in `TargetMOL.create`
- call `_export()` directly after preparing MOL

## Testing
- `PYTHONPATH=. pytest` *(fails: FileNotFoundError: system_settings.JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68b7527da6888330978df8fc1aeed67a