### PR TITLE
Filter postprocess data by time and improve error handling

### DIFF
--- a/FECalc/postprocess.py
+++ b/FECalc/postprocess.py
@@ -147,8 +147,7 @@ def _calc_deltaF(bound_data, unbound_data, KbT):
 def _calc_FE(ifdir, KbT, init_time, n_folds) -> None:
     colvars = _load_plumed(ifdir/"reweight"/"COLVAR", KbT) # read colvars
     print(f"INFO: Discarding initial {init_time} ns of data for free energy calculations.")
-    init_idx = int(init_time * 10000 // 2)
-    colvars = colvars.iloc[init_idx:] # discard the first `init_time` ns of data
+    colvars = colvars[colvars['time'] >= init_time * 1000]  # discard the first `init_time` ns of data
     # block analysis
     colvars.dropna(inplace=True)
     block_anal_data = _block_anal_3d(colvars.dcom, colvars.ang, 
@@ -168,13 +167,16 @@ def _calc_FE(ifdir, KbT, init_time, n_folds) -> None:
             unbound_data.rename(columns={i: 'F'}, inplace=True)
             unbound_data.dropna(inplace=True)
             f_list.append(_calc_deltaF(bound_data=bound_data, unbound_data=unbound_data, KbT=KbT))
-        except:
+        except (KeyError, ValueError) as e:
+            print(f"ERROR: {e}")
             discarded_blocks += 1
             continue
     
     if discarded_blocks != 0:
         print(f"WARNING: {discarded_blocks} block(s) were discarded from the calculations possibly because the system was"\
                 " stuck in a bound state for longer than 100 ns consecutively. Check the colvar trajectories.")
+    if not f_list:
+        raise ValueError("No free energy values could be calculated; f_list is empty.")
     f_list = np.array(f_list)
     return np.nanmean(f_list), np.nanstd(f_list)/np.sqrt(len(f_list)-np.count_nonzero(np.isnan(f_list)))
     

--- a/FECalc/scripts/postprocess.py
+++ b/FECalc/scripts/postprocess.py
@@ -138,8 +138,7 @@ def _calc_FE(ifdir) -> None:
     colvars = _load_plumed(ifdir/"reweight"/"COLVAR") # read colvars
     init_time = 100 # ns
     print(f"INFO: Discarding initial {init_time} ns of data for free energy calculations.")
-    init_idx = int(init_time * 10000 // 2)
-    colvars = colvars.iloc[init_idx:] # discard the first 100 ns of data
+    colvars = colvars[colvars['time'] >= init_time * 1000]  # discard the first `init_time` ns of data
     # block analysis
     colvars.dropna(inplace=True)
     block_anal_data = _block_anal_3d(colvars.dcom, colvars.ang, 
@@ -159,13 +158,16 @@ def _calc_FE(ifdir) -> None:
             unbound_data.rename(columns={i: 'F'}, inplace=True)
             unbound_data.dropna(inplace=True)
             f_list.append(_calc_deltaF(bound_data=bound_data, unbound_data=unbound_data))
-        except:
+        except (KeyError, ValueError) as e:
+            print(f"ERROR: {e}")
             discarded_blocks += 1
             continue
     
     if discarded_blocks != 0:
         print(f"WARNING: {discarded_blocks} block(s) were discarded from the calculations possibly because the system was"\
                 " stuck in a bound state for longer than 100 ns consecutively. Check the colvar trajectories.")
+    if not f_list:
+        raise ValueError("No free energy values could be calculated; f_list is empty.")
     f_list = np.array(f_list)
     return np.nanmean(f_list), np.nanstd(f_list)/np.sqrt(len(f_list)-np.count_nonzero(np.isnan(f_list)))
     


### PR DESCRIPTION
## Summary
- Filter out early trajectory frames by time instead of index
- Handle only KeyError/ValueError during free energy aggregation and log the issue
- Fail fast when no free energy values are produced

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'FECalc')*

------
https://chatgpt.com/codex/tasks/task_e_68b7528a0f3c83308973beff9e3b13ba