### PR TITLE
Remove unused PCC atom count field

### DIFF
--- a/FECalc/FECalc.py
+++ b/FECalc/FECalc.py
@@ -68,7 +68,6 @@ class FECalc():
         self.target_dir = self.target.base_dir/"export"
 
         self.PCC_charge = self.pcc.charge
-        self.PCC_n_atoms = self.pcc.n_atoms
         self.MOL_list = [] # list of MOL atom ids (str)
         self.PCC_list = [] # list of PCC atom ids (str)
         self.MOL_list_atom = [] # list of MOL atom names (str)


### PR DESCRIPTION
## Summary
- Drop `self.PCC_n_atoms` attribute from `FECalc` initialization since the value is unused

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in example/pcc_submit_test.py)*
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b755e380c4833097ef0e02f111509a