### PR TITLE
refactor: centralize cd context manager

### DIFF
--- a/FECalc/FECalc.py
+++ b/FECalc/FECalc.py
@@ -5,21 +5,7 @@ from pathlib import Path
 from datetime import datetime
 
 from .GMXitp.GMXitp import GMXitp
-
-class cd:
-    """Context manager for changing the current working directory"""
-    def __init__(self, newPath):
-        self.newPath = Path(newPath)
-
-    def __enter__(self):
-        self.savedPath = Path.cwd()
-        try:
-            os.chdir(self.newPath)
-        except (FileNotFoundError, NotADirectoryError) as e:
-            raise ValueError("Path does not exist.") from e
-
-    def __exit__(self, etype, value, traceback):
-        os.chdir(self.savedPath)
+from .utils import cd
 
 class FECalc():
     """

--- a/FECalc/utils.py
+++ b/FECalc/utils.py
@@ -73,6 +73,7 @@ def _prep_pdb(in_f_dir: Path, out_f_dir: Path, resname: str) -> None:
 
 class cd:
     """Context manager for changing the current working directory"""
+
     def __init__(self, newPath):
         self.newPath = Path(newPath)
 
@@ -80,8 +81,8 @@ class cd:
         self.savedPath = Path.cwd()
         try:
             os.chdir(self.newPath)
-        except:
-            raise ValueError("Path does not exist.")
+        except (FileNotFoundError, NotADirectoryError) as e:
+            raise ValueError("Path does not exist.") from e
 
     def __exit__(self, etype, value, traceback):
         os.chdir(self.savedPath)


### PR DESCRIPTION
## Summary
- remove duplicate `cd` context manager from `FECalc.py`
- host shared `cd` implementation in `utils.py`
- import `cd` from `utils` throughout the package

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'FECalc')*
- `pytest tests/test_posre_regeneration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b755f0863483309705bcf7eb945c1f