### PR TITLE
Fail on warnings in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
+filterwarnings = error


### PR DESCRIPTION
## Summary
- treat all warnings as errors via `filterwarnings = error`

## Testing
- `pytest` *(fails: invalid escape sequence `\d` errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b790f96c348330bd0bc213404a2f86