### PR TITLE
Use raw string regex patterns to silence escape warnings

### DIFF
--- a/FECalc/FECalc.py
+++ b/FECalc/FECalc.py
@@ -130,10 +130,10 @@ class FECalc():
         # get atom ids
         for line in atom_list:
             line_list = line.split()
-            if re.match("^\d+MOL$", line_list[0]):
+            if re.match(r"^\d+MOL$", line_list[0]):
                 MOL_list_id.append(int(line_list[2]))
                 MOL_list_atom.append(line_list[1])
-            elif re.match("^\d+PCC$", line_list[0]):
+            elif re.match(r"^\d+PCC$", line_list[0]):
                 PCC_list_id.append(int(line_list[2]))
                 PCC_list_atom.append(line_list[1])
         # save MOL_list and PCC_list

--- a/FECalc/GMXitp/GMXitp.py
+++ b/FECalc/GMXitp/GMXitp.py
@@ -25,7 +25,7 @@ class GMXitp():
         end_line = None
 
         for i, line in enumerate(itp_cnt): # get the starting lines first
-            if re.search("\[.*[a-z]+.*\]", line):
+            if re.search(r"\[.*[a-z]+.*\]", line):
                 title = "".join(line.split())
                 title = title[1:-1]
                 if not(start_line is None):

--- a/FECalc/postprocess.py
+++ b/FECalc/postprocess.py
@@ -206,7 +206,7 @@ def _calc_FE(ifdir, KbT, init_time, n_folds) -> None:
     box_size = _get_box_size(ifdir/"md"/"md.gro")
     unbound_max = box_size / 2
     f_list = []
-    f_cols = [col for col in block_anal_data.columns if re.match("f_\d+", col)]
+    f_cols = [col for col in block_anal_data.columns if re.match(r"f_\d+", col)]
     discarded_blocks = 0
     for i in f_cols:
         try:


### PR DESCRIPTION
## Summary
- Treat regex patterns as raw strings to prevent escape sequence warnings
- Update FECalc, GMXitp, and postprocess modules accordingly

## Testing
- `pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_68b790eb4edc833093e37c6b2c266a9b