### PR TITLE
Run TargetMOL minimization with Python

### DIFF
--- a/FECalc/TargetMOL.py
+++ b/FECalc/TargetMOL.py
@@ -134,7 +134,7 @@ class TargetMOL():
     def _minimize_MOL(self, wait: bool = True) -> None: 
         """
         Run minimization for MOL. Copies acpype files into `em` directory, solvates, adds ions, and minimizes
-        the structure. The last frame is saved as `MOL.gro`
+        the structure. The final coordinates are converted from `em.gro` to `MOL_em.pdb`.
 
         Args:
             wait (bool, optional): Whether to wait for `em` to finish. Defaults to True.
@@ -151,12 +151,48 @@ class TargetMOL():
             subprocess.run(["cp", f"{self.mold_dir}/PCC/em/topol.top", "."], check=True)
             subprocess.run(["cp", f"{self.mold_dir}/PCC/em/ions.mdp", "."], check=True)
             subprocess.run(["cp", f"{self.mold_dir}/PCC/em/em.mdp", "."], check=True)
-            subprocess.run(["cp", f"{self.mold_dir}/PCC/em/sub_mdrun_em.sh", "."], check=True) # copy mdrun submission script
             # fix topol.top
             subprocess.run(f"sed -i 's/PCC/MOL/g' topol.top", shell=True)
-            # submit em job
-            wait_str = " --wait " if wait else "" # whether to wait for em to finish before exiting
-            subprocess.run(f"sbatch -J MOL{wait_str}sub_mdrun_em.sh MOL {self.charge}", check=True, shell=True)
+
+            # Determine total number of threads for mdrun from Slurm env vars
+            ncpu = int(os.environ.get("SLURM_NTASKS_PER_NODE", 1))
+            nthr = int(os.environ.get("SLURM_CPUS_PER_TASK", 1))
+            nnod = int(os.environ.get("SLURM_JOB_NUM_NODES", 1))
+            np = ncpu * nthr * nnod
+
+            # Create box
+            subprocess.run([
+                "gmx", "editconf", "-f", "MOL_GMX.gro", "-o", "MOL_box.gro", "-c", "-d", "1.0", "-bt", "cubic"
+            ], check=True)
+
+            # Solvate
+            subprocess.run([
+                "gmx", "solvate", "-cp", "MOL_box.gro", "-cs", "spc216.gro", "-o", "MOL_sol.gro", "-p", "topol.top"
+            ], check=True)
+
+            # Neutralize if needed and prepare tpr
+            if self.charge != 0:
+                subprocess.run([
+                    "gmx", "grompp", "-f", "ions.mdp", "-c", "MOL_sol.gro", "-p", "topol.top", "-o", "ions.tpr", "-maxwarn", "2"
+                ], check=True)
+                subprocess.run([
+                    "gmx", "genion", "-s", "ions.tpr", "-o", "MOL_sol_ions.gro", "-p", "topol.top", "-pname", "NA", "-nname", "CL", "-neutral"
+                ], input="4\n", text=True, check=True)
+                subprocess.run([
+                    "gmx", "grompp", "-f", "em.mdp", "-c", "MOL_sol_ions.gro", "-p", "topol.top", "-o", "em.tpr"
+                ], check=True)
+            else:
+                subprocess.run([
+                    "gmx", "grompp", "-f", "em.mdp", "-c", "MOL_sol.gro", "-p", "topol.top", "-o", "em.tpr"
+                ], check=True)
+
+            # Run minimization
+            subprocess.run(["gmx", "mdrun", "-ntomp", str(np), "-deffnm", "em"], check=True)
+
+            # Convert minimized structure to PDB
+            subprocess.run([
+                "gmx", "trjconv", "-s", "em.tpr", "-f", "em.gro", "-o", "MOL_em.pdb", "-pbc", "whole", "-conect"
+            ], input="2\n", text=True, check=True)
         self._set_done(self.base_dir/"em")
 
         return None

--- a/tests/test_targetmol.py
+++ b/tests/test_targetmol.py
@@ -208,11 +208,10 @@ def test_minimize_mol_copies_files_and_runs(tmp_path, monkeypatch, wait_flag):
     em_dir = tm.base_dir / "em"
     assert (em_dir / "MOL_GMX.gro").exists()
     assert "MOL" in (em_dir / "topol.top").read_text()
-    sbatch_cmd = [c for c in commands if isinstance(c, str) and c.startswith("sbatch")][0]
-    if wait_flag:
-        assert "--wait" in sbatch_cmd
-    else:
-        assert "--wait" not in sbatch_cmd
+    assert any(c.startswith("gmx editconf") for c in commands)
+    assert any(c.startswith("gmx mdrun") for c in commands)
+    assert any(c.startswith("gmx trjconv") for c in commands)
+    assert not any("sbatch" in c for c in commands)
     assert (em_dir / ".done").exists()
 
 


### PR DESCRIPTION
## Summary
- replace `sub_mdrun_em.sh` usage with direct Gromacs calls in `TargetMOL._minimize_MOL`
- generate `MOL_em.pdb` from `em.gro` instead of last trajectory frame
- update TargetMOL tests for new workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a4230b588330956b6c77a40438c4