### PR TITLE
Remove unused wait feature for sequential execution

### DIFF
--- a/FECalc/FECalc.py
+++ b/FECalc/FECalc.py
@@ -351,16 +351,12 @@ class FECalc():
         )
         return None
     
-    def _eq_complex(self, wait: bool = True) -> None:
+    def _eq_complex(self) -> None:
         """Solvate and equilibrate the PCC–target complex.
 
         Energy minimization, NVT, and NPT simulations are run sequentially.
         After minimization, atom indices are updated and position restraint
         files are regenerated.
-
-        Args:
-            wait (bool, optional): Whether to wait for each simulation stage to
-                finish. Defaults to ``True``.
 
         Returns:
             None
@@ -565,7 +561,7 @@ class FECalc():
 
         return None
 
-    def _pbmetaD(self, wait: bool = True) -> None:
+    def _pbmetaD(self) -> None:
         """Run parallel-bias metadynamics (PBMetaD) from the equilibrated structure.
 
         The method prepares PLUMED inputs with the correct atom IDs and
@@ -573,10 +569,6 @@ class FECalc():
         workflow automatically resumes from a checkpoint if one is detected,
         replicating the behaviour previously implemented in the
         ``sub_mdrun_plumed.sh`` helper script.
-
-        Args:
-            wait (bool, optional): Whether to wait for the PBMetaD run to
-                complete. Defaults to ``True``.
 
         Returns:
             None
@@ -713,7 +705,7 @@ class FECalc():
         self._set_done(self.complex_dir/'md')
         return None
     
-    def _reweight(self, wait: bool = True) -> None:
+    def _reweight(self) -> None:
         """Reweight the results of the PBMetaD run.
 
         This is achieved by using a ``plumed`` reweighting script that
@@ -721,10 +713,6 @@ class FECalc():
         PBMetaD simulation and creates a new COLVARS file with the converged
         values of bias which is used by ``postprocess`` to calculate the free
         energy.
-
-        Args:
-            wait (bool, optional): Whether to wait for the reweighting job to
-                finish. Defaults to ``True``.
 
         Returns:
             None
@@ -754,10 +742,7 @@ class FECalc():
                 "-plumed", "reweight.dat", "-s", "../md/md.tpr",
                 "-rerun", "../md/md.xtc",
             ]
-            if wait:
-                subprocess.run(cmd, check=True)
-            else:
-                subprocess.Popen(cmd)
+            subprocess.run(cmd, check=True)
         self._set_done(self.complex_dir/'reweight')
         return None
 

--- a/FECalc/PCCBuilder.py
+++ b/FECalc/PCCBuilder.py
@@ -145,7 +145,7 @@ class PCCBuilder():
         self._set_done(self.PCC_dir) # mark stage as done
         return None
     
-    def _get_params(self, wait: bool = True) -> None:
+    def _get_params(self) -> None:
         """Generate GAFF parameters for the mutated PCC using ``acpype``.
 
         The procedure is carried out in several steps:
@@ -156,10 +156,6 @@ class PCCBuilder():
         3. Inspect ``PCC.acpype/acpype.log`` for the presence of the word
            ``warning``. Any warning triggers a ``RuntimeError`` because it
            indicates that the generated topology may contain incorrect bonds.
-
-        Args:
-            wait (bool, optional): Retained for backward compatibility; has no
-                effect as ``acpype`` now runs synchronously.
 
         Raises:
             RuntimeError: If ``acpype.log`` contains warnings suggesting the
@@ -200,17 +196,13 @@ class PCCBuilder():
         self._set_done(self.PCC_dir/"PCC.acpype")
         return None
     
-    def _minimize_PCC(self, wait: bool = True) -> None:
+    def _minimize_PCC(self) -> None:
         """Run energy minimization for the PCC using ``gmx`` commands.
 
         The method mirrors the behaviour of the previous ``sub_mdrun_em.sh``
         script directly in Python. It creates a solvated box, adds counter
         ions if necessary, performs energy minimization, and converts the
         minimized structure to ``{PCC_code}_em.pdb``.
-
-        Args:
-            wait (bool, optional): Retained for API compatibility. The
-                operations run synchronously and this flag has no effect.
 
         Returns:
             None

--- a/FECalc/TargetMOL.py
+++ b/FECalc/TargetMOL.py
@@ -132,13 +132,10 @@ class TargetMOL():
         self._set_done(self.base_dir / "MOL.acpype")
         return None
     
-    def _minimize_MOL(self, wait: bool = True) -> None: 
+    def _minimize_MOL(self) -> None:
         """
         Run minimization for MOL. Copies acpype files into `em` directory, solvates, adds ions, and minimizes
         the structure. The final coordinates are converted from `em.gro` to `MOL_em.pdb`.
-
-        Args:
-            wait (bool, optional): Whether to wait for `em` to finish. Defaults to True.
 
         Returns:
             None

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -36,7 +36,7 @@ def test_minimal_end_to_end(tmp_path, monkeypatch):
         self.complex_dir.mkdir(parents=True, exist_ok=True)
         (self.complex_dir / ".done").touch()
 
-    def fake_eq_complex(self, wait=True):
+    def fake_eq_complex(self):
         em_dir = self.complex_dir / "em"
         em_dir.mkdir(parents=True, exist_ok=True)
         em_dir.joinpath("em.gro").write_text(
@@ -48,7 +48,7 @@ def test_minimal_end_to_end(tmp_path, monkeypatch):
             sdir.mkdir(parents=True, exist_ok=True)
             (sdir / ".done").touch()
 
-    def fake_pbmetad(self, wait=True):
+    def fake_pbmetad(self):
         md_dir = self.complex_dir / "md"
         md_dir.mkdir(parents=True, exist_ok=True)
         md_dir.joinpath("md.gro").write_text(
@@ -59,7 +59,7 @@ def test_minimal_end_to_end(tmp_path, monkeypatch):
         md_dir.joinpath("GRID_cos").write_text("0\n")
         (md_dir / ".done").touch()
 
-    def fake_reweight(self, wait=True):
+    def fake_reweight(self):
         re_dir = self.complex_dir / "reweight"
         re_dir.mkdir(parents=True, exist_ok=True)
         re_dir.joinpath("COLVAR").write_text(

--- a/tests/test_pccbuilder.py
+++ b/tests/test_pccbuilder.py
@@ -191,7 +191,7 @@ def test_minimize_pcc_runs_and_marks_done(tmp_path, monkeypatch):
     monkeypatch.setattr(pccb, "subprocess", SimpleNamespace(run=fake_run))
     monkeypatch.setattr(pccb, "cd", dummy_cd)
 
-    builder._minimize_PCC(wait=False)
+    builder._minimize_PCC()
 
     assert any("gmx mdrun" in str(c) for c in calls)
     assert any(

--- a/tests/test_targetmol.py
+++ b/tests/test_targetmol.py
@@ -163,8 +163,7 @@ def test_get_params_raises_on_warning(tmp_path, monkeypatch):
         tm._get_params()
 
 
-@pytest.mark.parametrize("wait_flag", [True, False])
-def test_minimize_mol_copies_files_and_runs(tmp_path, monkeypatch, wait_flag):
+def test_minimize_mol_copies_files_and_runs(tmp_path, monkeypatch):
     tm = _init_target(tmp_path)
 
     # set up acpype files
@@ -200,7 +199,7 @@ def test_minimize_mol_copies_files_and_runs(tmp_path, monkeypatch, wait_flag):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    tm._minimize_MOL(wait=wait_flag)
+    tm._minimize_MOL()
 
     em_dir = tm.base_dir / "em"
     assert (em_dir / "MOL_GMX.gro").exists()
@@ -251,7 +250,7 @@ def test_create_runs_stages_conditionally(tmp_path, monkeypatch):
         calls.append("get")
         self._set_done(self.base_dir / "MOL.acpype")
 
-    def fake_minimize(self, wait=True):
+    def fake_minimize(self):
         calls.append("min")
         self._set_done(self.base_dir / "em")
 


### PR DESCRIPTION
## Summary
- drop `wait` parameters from workflow helpers to enforce sequential execution
- run reweighting synchronously and update API accordingly
- adjust tests for new synchronous behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87c7869f88330a37ed004f54a4b6b