### PR TITLE
Declare acpype and PyMOL runtime dependencies

### DIFF
--- a/FECalc/scripts/__init__.py
+++ b/FECalc/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Runtime scripts used by FECalc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,6 @@ where = ["."]
 include = ["FECalc", "FECalc.*"]
 
 [tool.setuptools.package-data]
-"FECalc" = ["PCCBuilder_settings.JSON", "scripts/*.pdb"]
+"FECalc" = ["PCCBuilder_settings.JSON"]
+"FECalc.scripts" = ["*.pdb"]
 


### PR DESCRIPTION
## Summary
- Add `acpype` and `pymol-open-source` as runtime dependencies
- Document automatic installation of PyMOL and acpype
- Use environment `pymol` instead of JSON-configured path
- Package runtime scripts so PyMOL helper files are distributed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b899c70a2083308f64922ab0ef1489