### PR TITLE
feat: expose main classes in package

### DIFF
--- a/FECalc/__init__.py
+++ b/FECalc/__init__.py
@@ -1,0 +1,17 @@
+"""Convenience imports for FECalc package."""
+
+from .FECalc import FECalc as _FECalc
+from .PCCBuilder import PCCBuilder as _PCCBuilder
+from .TargetMOL import TargetMOL as _TargetMOL
+
+__all__ = ["FECalc", "PCCBuilder", "TargetMOL"]
+
+
+def __getattr__(name):
+    if name == "FECalc":
+        return _FECalc
+    if name == "PCCBuilder":
+        return _PCCBuilder
+    if name == "TargetMOL":
+        return _TargetMOL
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- Expose `FECalc`, `PCCBuilder`, and `TargetMOL` classes directly from the FECalc package
- Clarify package API with `__all__` and lazy attribute access

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b89bbb1ad88330a594e1cafddf953c