### PR TITLE
Hardcode reference PCC path

### DIFF
--- a/FECalc/PCCBuilder.py
+++ b/FECalc/PCCBuilder.py
@@ -59,7 +59,7 @@ class PCCBuilder():
         self.PCC_dir = self.base_dir/f"{self.PCC_code}" # directory to store PCC calculations
         self.PCC_dir.mkdir(exist_ok=True)
 
-        self.PCC_ref = Path(self.settings["ref_PCC_dir"]) # path to refrence PCC structure
+        self.PCC_ref = self.script_dir / "GGGGG.pdb"  # path to reference PCC structure
         
         self.AAdict31 = {'CYS': 'C', 'ASP': 'D', 'SER': 'S', 'GLN': 'Q', 'LYS': 'K',
                          'ILE': 'I', 'PRO': 'P', 'THR': 'T', 'PHE': 'F', 'ASN': 'N', 

--- a/FECalc/PCCBuilder_settings.JSON
+++ b/FECalc/PCCBuilder_settings.JSON
@@ -1,5 +1,4 @@
 {
-    "ref_PCC_dir": "scripts/GGGGG.pdb",
     "origin": ["N4", "C10", "C11", "O1"],
     "anchor1": ["C1", "C2", "C3", "O"],
     "anchor2": ["N1", "N2", "N3", "C7", "C8"]

--- a/tests/test_pccbuilder.py
+++ b/tests/test_pccbuilder.py
@@ -16,7 +16,6 @@ from FECalc.PCCBuilder import PCCBuilder
 
 def make_settings(tmp_path):
     settings = {
-        "ref_PCC_dir": "ref.pdb",
         "origin": [0, 0, 0],
         "anchor1": [0, 0, 0],
         "anchor2": [1, 0, 0],


### PR DESCRIPTION
## Summary
- Hardcode GGGGG.pdb location in PCCBuilder instead of reading from settings
- Drop `ref_PCC_dir` from default PCCBuilder settings JSON
- Adjust unit tests for new settings format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b77c4f0083309c55b8294ce54ee2