### PR TITLE
Reorganize documentation structure

### DIFF
--- a/docs/examples/example1.md
+++ b/docs/examples/example1.md
@@ -1,4 +1,4 @@
-# Examples
+# Example 1
 
 The `example` directory demonstrates how to run a complete binding free energy calculation with PCC-FECalc.  It contains sample settings files and a submission script:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@
 
 This repository provides a python framework for performing binding free energy calculations for a user-defined target molecule and a protein-catalyzed capture (PCC) agent with a user-defined epitope sequence. The core of this package is based on ["High-throughput virtual screening of protein-catalyzed capture agents for novel hydrogel-nanoparticle fentanyl sensors"](10.26434/chemrxiv-2025-psxft) and the corresponding [repository](https://github.com/Ferg-Lab/FEN-HTVS). Please refer to the original paper for a more technical explanation of the theory and the setup behind the free energy calculations done with this framework.
 
+For setup instructions, see [Installation instructions](installation/instructions.md).
+
 ---
 
 ## 🚀 Features
@@ -17,22 +19,6 @@ The framework is organized into four main submodules that work in serial to perf
 
 ---
 
-## 📦 Installation
-
-### Clone the repository
-
-``` bash
-    git clone https://github.com/arminshzd/PCC-FECalc.git
-    cd PCC-FECalc
-```
-
-### Install
-
-``` bash
-pip install -e .
-```
-
----
 
 ## 🛠 Usage
 

--- a/docs/installation/instructions.md
+++ b/docs/installation/instructions.md
@@ -1,0 +1,11 @@
+# Instructions
+
+To install PCC-FECalc from source, clone the repository and install the package in editable mode:
+
+```bash
+git clone https://github.com/arminshzd/PCC-FECalc.git
+cd PCC-FECalc
+pip install -e .
+```
+
+> **Note:** PyMOL is required but not installed automatically because no pip wheel is available. Install PyMOL separately from [pymol.org](https://www.pymol.org/) or the open-source repository at [github.com/schrodinger/pymol-open-source](https://github.com/schrodinger/pymol-open-source), and ensure the `pymol` executable is on your `PATH`.

--- a/docs/installation/modifications.md
+++ b/docs/installation/modifications.md
@@ -1,0 +1,9 @@
+# Modifications
+
+The default installation covers the core features of PCC-FECalc. Depending on your workflow, you may wish to install optional extras or adjust configuration files:
+
+- **Documentation build**: `pip install .[docs]` installs `mkdocs` and related plugins for building the documentation.
+- **Testing**: `pip install .[test]` installs `pytest` for running the test suite.
+- **Scheduler settings**: edit the `system_settings.JSON` example to match your cluster's scheduler (e.g., `slurm`, `pbs`, or `lsf`).
+
+These adjustments allow the package to integrate with different environments and use cases.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,12 @@
 site_name: PCC-FECalc
 nav:
-  - Home: index.md
-  - API Reference: api.md
-  - Examples: examples.md
+  - PCC-FECalc: index.md
+  - Installation:
+      - Instructions: installation/instructions.md
+      - Modifications: installation/modifications.md
+  - Examples:
+      - Example 1: examples/example1.md
+  - API docs: api.md
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
## Summary
- Restructure MkDocs navigation with landing page, installation section, example, and API docs
- Add dedicated installation instructions and modifications pages
- Move example content into `examples/example1.md` and link from index

## Testing
- `mkdocs build` *(passes, with warnings)*
- `pytest` *(fails: FileNotFoundError for FECalc/scripts/PCC/em/topol.top)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e2c053548330a2c3813afccbd111