### PR TITLE
Fix PCC minimization GMX input name

### DIFF
--- a/FECalc/PCCBuilder.py
+++ b/FECalc/PCCBuilder.py
@@ -248,7 +248,7 @@ class PCCBuilder():
 
             # construct simulation box and solvate
             run_gmx(
-                f"gmx editconf -f {self.PCC_code}_GMX.gro -o {self.PCC_code}_box.gro -c -d 1.0 -bt cubic"
+                f"gmx editconf -f PCC_GMX.gro -o {self.PCC_code}_box.gro -c -d 1.0 -bt cubic"
             )
             run_gmx(
                 f"gmx solvate -cp {self.PCC_code}_box.gro -cs spc216.gro -o {self.PCC_code}_sol.gro -p topol.top"

--- a/tests/test_pccbuilder.py
+++ b/tests/test_pccbuilder.py
@@ -191,6 +191,13 @@ def test_minimize_pcc_runs_and_marks_done(tmp_path, monkeypatch):
 
     builder._minimize_PCC()
 
+    assert any(
+        isinstance(c, str)
+        and "gmx editconf" in c
+        and "PCC_GMX.gro" in c
+        and f"{builder.PCC_code}_box.gro" in c
+        for c in calls
+    )
     assert any("gmx mdrun" in str(c) for c in calls)
     assert any(
         isinstance(c, str)


### PR DESCRIPTION
## Summary
- run `gmx editconf` on the copied `PCC_GMX.gro` file during PCC minimization
- test `_minimize_PCC` to ensure the correct file name is used

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8e4c804548330a0aa15da5a5c90cb