### PR TITLE
refactor: replace sed with python file edits

### DIFF
--- a/FECalc/TargetMOL.py
+++ b/FECalc/TargetMOL.py
@@ -166,7 +166,10 @@ class TargetMOL():
             subprocess.run(["cp", f"{self.script_dir}/PCC/em/ions.mdp", "."], check=True)
             subprocess.run(["cp", f"{self.script_dir}/PCC/em/em.mdp", "."], check=True)
             # fix topol.top
-            subprocess.run(f"sed -i 's/PCC/MOL/g' topol.top", shell=True)
+            topol_path = Path("topol.top")
+            topol_text = topol_path.read_text()
+            topol_text = topol_text.replace("PCC", "MOL")
+            topol_path.write_text(topol_text)
 
             # Determine total number of threads for mdrun
             np = self.nodes * self.cores * self.threads

--- a/tests/test_targetmol.py
+++ b/tests/test_targetmol.py
@@ -191,10 +191,6 @@ def test_minimize_mol_copies_files_and_runs(tmp_path, monkeypatch):
                 (dst_path / src_path.name).write_text(src_path.read_text())
             else:
                 dst_path.write_text(src_path.read_text())
-        elif isinstance(cmd, str) and cmd.startswith("sed -i"):
-            target = tm.base_dir / "em" / "topol.top"
-            text = target.read_text().replace("PCC", "MOL")
-            target.write_text(text)
         return subprocess.CompletedProcess(cmd, 0)
 
     monkeypatch.setattr(subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary
- remove `sed` dependency in `_minimize_MOL` by editing `topol.top` with pathlib
- adjust tests to align with Python-native editing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8e921176c83309a8e5772822e1a59