### PR TITLE
fix: remove solvent from PCC trjconv output

### DIFF
--- a/FECalc/PCCBuilder.py
+++ b/FECalc/PCCBuilder.py
@@ -276,9 +276,24 @@ class PCCBuilder():
                 f"gmx mdrun -ntomp {np_total} -deffnm em"
             )
 
-            # convert the resulting em.gro to the final minimized PDB
+            # convert the resulting em.gro to the final minimized PDB while
+            # removing all solvent molecules
             run_gmx(
-                f"gmx editconf -f em.gro -o {self.PCC_code}_em.pdb"
+                [
+                    "gmx",
+                    "trjconv",
+                    "-s",
+                    "em.tpr",
+                    "-f",
+                    "em.gro",
+                    "-o",
+                    f"{self.PCC_code}_em.pdb",
+                    "-pbc",
+                    "whole",
+                    "-conect",
+                ],
+                input="1\n",
+                text=True,
             )
 
         self._set_done(self.PCC_dir / "em")

--- a/tests/test_pccbuilder.py
+++ b/tests/test_pccbuilder.py
@@ -200,8 +200,9 @@ def test_minimize_pcc_runs_and_marks_done(tmp_path, monkeypatch):
     )
     assert any("gmx mdrun" in str(c) for c in calls)
     assert any(
-        isinstance(c, str)
-        and "gmx editconf" in c
+        isinstance(c, (list, tuple))
+        and "gmx" in c
+        and "trjconv" in c
         and "em.gro" in c
         and f"{builder.PCC_code}_em.pdb" in c
         for c in calls


### PR DESCRIPTION
## Summary
- Use gmx trjconv to strip solvent from minimized PCC structure
- Update PCCBuilder test to expect trjconv output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8ed89692c83308e194d3bf582bf18