### PR TITLE
Document AmberTools dependency for sqm

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ The framework is organized into four main submodules that work in serial to perf
 pip install -e .
 ```
 
-> **Note:** PyMOL is required but not installed automatically because no pip wheel is available. Install PyMOL separately from [pymol.org](https://www.pymol.org/) or the open-source repository at [github.com/schrodinger/pymol-open-source](https://github.com/schrodinger/pymol-open-source), and ensure the `pymol` executable is on your `PATH`.
+After the package is installed, add AmberTools and `libgfortran5` so the `sqm` program works:
+
+``` bash
+conda install -c conda-forge ambertools libgfortran5
+```
+
+> **Note:** PyMOL is required but not installed automatically because no pip wheel is available. Install PyMOL separately from [pymol.org](https://www.pymol.org/) or build from the open-source [GitHub repository](https://github.com/schrodinger/pymol-open-source). There's also a conda package package available:
+>
+> ```bash
+> conda install -c conda-forge pymol-open-source
+> ```
+>
+> Ensure the `pymol` executable is on your `PATH`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,19 @@ The framework is organized into four main submodules that work in serial to perf
 
 See `example/pcc_submit_test.py` for a sample calculation setup.
 
-This framework additionally relies on PyMOL and `acpype` for PCC mutations and GAFF2 parameter generation. Both are installed automatically as the `pymol-open-source` and `acpype` Python packages. Ensure the `pymol` executable is available on your `PATH`.
+This framework additionally relies on PyMOL and `acpype` for PCC mutations and GAFF2 parameter generation. `acpype` is installed automatically as a Python package. PyMOL is required but not installed automatically because no pip wheel is available. Install PyMOL separately from [pymol.org](https://www.pymol.org/) or build from the open-source [GitHub repository](https://github.com/schrodinger/pymol-open-source). There's also a conda package package available:
+
+```bash
+conda install -c conda-forge pymol-open-source
+```
+
+Ensure the `pymol` executable is on your `PATH`.
+
+The `acpype` workflow uses the `sqm` program from AmberTools, so install AmberTools and `libgfortran5` after setting up the repository:
+
+```bash
+conda install -c conda-forge ambertools libgfortran5
+```
 
 The calculations happen through four steps and each step requires a `JSON` files with the necessary user parameters:
 

--- a/docs/installation/instructions.md
+++ b/docs/installation/instructions.md
@@ -8,4 +8,16 @@ cd PCC-FECalc
 pip install -e .
 ```
 
-> **Note:** PyMOL is required but not installed automatically because no pip wheel is available. Install PyMOL separately from [pymol.org](https://www.pymol.org/) or the open-source repository at [github.com/schrodinger/pymol-open-source](https://github.com/schrodinger/pymol-open-source), and ensure the `pymol` executable is on your `PATH`.
+After installing the repository, add AmberTools and `libgfortran5` to enable the `sqm` program:
+
+```bash
+conda install -c conda-forge ambertools libgfortran5
+```
+
+> **Note:** PyMOL is required but not installed automatically because no pip wheel is available. Install PyMOL separately from [pymol.org](https://www.pymol.org/) or build from the open-source [GitHub repository](https://github.com/schrodinger/pymol-open-source). There's also a conda package package available:
+>
+> ```bash
+> conda install -c conda-forge pymol-open-source
+> ```
+>
+> Ensure the `pymol` executable is on your `PATH`.

--- a/docs/installation/modifications.md
+++ b/docs/installation/modifications.md
@@ -1,5 +1,19 @@
 # Modifications
 
+AmberTools' `sqm` executable is required for parameter generation and depends on `libgfortran5`. Install them after setting up the repository:
+
+```bash
+conda install -c conda-forge ambertools libgfortran5
+```
+
+PyMOL is required but not installed automatically because no pip wheel is available. Install PyMOL separately from [pymol.org](https://www.pymol.org/) or build from the open-source [GitHub repository](https://github.com/schrodinger/pymol-open-source). There's also a conda package package available:
+
+```bash
+conda install -c conda-forge pymol-open-source
+```
+
+Ensure the `pymol` executable is on your `PATH`.
+
 The default installation covers the core features of PCC-FECalc. Depending on your workflow, you may wish to install optional extras or adjust configuration files:
 
 - **Documentation build**: `pip install .[docs]` installs `mkdocs` and related plugins for building the documentation.


### PR DESCRIPTION
## Summary
- note that AmberTools and libgfortran5 must be installed for the `sqm` program
- document the `pymol-open-source` conda package for installing PyMOL
- reference the open-source PyMOL GitHub repository in setup instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9bdf464408330b2aa7a36e73111d6