### PR TITLE
Handle FECalc base directory creation more robustly

### DIFF
--- a/FECalc/FECalc.py
+++ b/FECalc/FECalc.py
@@ -60,7 +60,7 @@ class FECalc():
             now = datetime.now()
             now = now.strftime("%m/%d/%Y, %H:%M:%S")
             print(f"{now}: Base directory does not exist. Creating...")
-            self.base_dir.mkdir()
+            self.base_dir.mkdir(parents=True, exist_ok=True)
 
         self.PCC_dir = self.pcc.PCC_dir # directory to store PCC calculations
 


### PR DESCRIPTION
## Summary
- Safely create the FECalc base directory and any missing parents

## Testing
- `PYTHONPATH=.. python example/pcc_submit_example.py` *(fails: FileNotFoundError: PCCBuilder_settings.JSON)*
- `python - <<'PY'
from pathlib import Path
from FECalc.FECalc import FECalc

class DummyPCC:
    PCC_code='DUMMY'; PCC_dir=Path('dummy_pcc'); charge=0
class DummyTarget:
    name='DUM'; base_dir=Path('dummy_target')

import shutil
shutil.rmtree('dummy_base', ignore_errors=True)
shutil.rmtree('dummy_target', ignore_errors=True)

FECalc(DummyPCC(), DummyTarget(), Path('dummy_base'), temp=300, box=5.0)
print('Base dir exists:', Path('dummy_base').exists())
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9c5e7b8b483308e572adb4592ab40